### PR TITLE
Ensure that tuple variants are generated properly

### DIFF
--- a/__fixtures__/abstract/apps/ibcmail/client.json
+++ b/__fixtures__/abstract/apps/ibcmail/client.json
@@ -1,0 +1,986 @@
+{
+  "contract_name": "module-schema",
+  "contract_version": "0.22.1",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "App instantiate message",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "App execute messages",
+    "oneOf": [
+      {
+        "description": "Send a message",
+        "type": "object",
+        "required": [
+          "send_message"
+        ],
+        "properties": {
+          "send_message": {
+            "type": "object",
+            "required": [
+              "message"
+            ],
+            "properties": {
+              "message": {
+                "$ref": "#/definitions/NewMessage"
+              },
+              "route": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/AccountTrace"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Receive a message from the server",
+        "type": "object",
+        "required": [
+          "receive_message"
+        ],
+        "properties": {
+          "receive_message": {
+            "$ref": "#/definitions/Message"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Update the client configuration",
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "AccountId": {
+        "description": "Unique identifier for an account. On each chain this is unique.",
+        "type": "object",
+        "required": [
+          "seq",
+          "trace"
+        ],
+        "properties": {
+          "seq": {
+            "description": "Unique identifier for the accounts create on a local chain. Is reused when creating an interchain account.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "trace": {
+            "description": "Sequence of the chain that triggered the IBC account creation `AccountTrace::Local` if the account was created locally Example: Account created on Juno which has an abstract interchain account on Osmosis, which in turn creates an interchain account on Terra -> `AccountTrace::Remote(vec![\"juno\", \"osmosis\"])`",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AccountTrace"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "AccountTrace": {
+        "description": "The identifier of chain that triggered the account creation",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "local"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "remote"
+            ],
+            "properties": {
+              "remote": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ChainName"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ChainName": {
+        "description": "The name of a chain, aka the chain-id without the post-fix number. ex. `cosmoshub-4` -> `cosmoshub`, `juno-1` -> `juno`",
+        "type": "string"
+      },
+      "Message": {
+        "type": "object",
+        "required": [
+          "body",
+          "id",
+          "recipient",
+          "sender",
+          "subject",
+          "timestamp",
+          "version"
+        ],
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "recipient": {
+            "$ref": "#/definitions/Recipient"
+          },
+          "sender": {
+            "$ref": "#/definitions/Sender"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "timestamp": {
+            "$ref": "#/definitions/Timestamp"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Namespace": {
+        "description": "Represents an Abstract namespace for modules",
+        "type": "string"
+      },
+      "NewMessage": {
+        "description": "STruct representing new message to send to another client",
+        "type": "object",
+        "required": [
+          "body",
+          "recipient",
+          "subject"
+        ],
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "recipient": {
+            "$ref": "#/definitions/Recipient"
+          },
+          "subject": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Recipient": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "account"
+            ],
+            "properties": {
+              "account": {
+                "type": "object",
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "chain": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/ChainName"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "id": {
+                    "$ref": "#/definitions/AccountId"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "namespace"
+            ],
+            "properties": {
+              "namespace": {
+                "type": "object",
+                "required": [
+                  "namespace"
+                ],
+                "properties": {
+                  "chain": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/ChainName"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "namespace": {
+                    "$ref": "#/definitions/Namespace"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Sender": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "account"
+            ],
+            "properties": {
+              "account": {
+                "type": "object",
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "chain": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/ChainName"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "id": {
+                    "$ref": "#/definitions/AccountId"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "App query messages",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "list_messages"
+        ],
+        "properties": {
+          "list_messages": {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "properties": {
+              "filter": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/MessageFilter"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "$ref": "#/definitions/MessageStatus"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "messages"
+        ],
+        "properties": {
+          "messages": {
+            "type": "object",
+            "required": [
+              "ids",
+              "status"
+            ],
+            "properties": {
+              "ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "status": {
+                "$ref": "#/definitions/MessageStatus"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "AccountId": {
+        "description": "Unique identifier for an account. On each chain this is unique.",
+        "type": "object",
+        "required": [
+          "seq",
+          "trace"
+        ],
+        "properties": {
+          "seq": {
+            "description": "Unique identifier for the accounts create on a local chain. Is reused when creating an interchain account.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "trace": {
+            "description": "Sequence of the chain that triggered the IBC account creation `AccountTrace::Local` if the account was created locally Example: Account created on Juno which has an abstract interchain account on Osmosis, which in turn creates an interchain account on Terra -> `AccountTrace::Remote(vec![\"juno\", \"osmosis\"])`",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AccountTrace"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "AccountTrace": {
+        "description": "The identifier of chain that triggered the account creation",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "local"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "remote"
+            ],
+            "properties": {
+              "remote": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ChainName"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ChainName": {
+        "description": "The name of a chain, aka the chain-id without the post-fix number. ex. `cosmoshub-4` -> `cosmoshub`, `juno-1` -> `juno`",
+        "type": "string"
+      },
+      "MessageFilter": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Sender"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageStatus": {
+        "type": "string",
+        "enum": [
+          "sent",
+          "received"
+        ]
+      },
+      "Sender": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "account"
+            ],
+            "properties": {
+              "account": {
+                "type": "object",
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "chain": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/ChainName"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "id": {
+                    "$ref": "#/definitions/AccountId"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "migrate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MigrateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "sudo": null,
+  "responses": {
+    "config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ConfigResponse",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "list_messages": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "MessagesResponse",
+      "type": "object",
+      "required": [
+        "messages"
+      ],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Message"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "AccountId": {
+          "description": "Unique identifier for an account. On each chain this is unique.",
+          "type": "object",
+          "required": [
+            "seq",
+            "trace"
+          ],
+          "properties": {
+            "seq": {
+              "description": "Unique identifier for the accounts create on a local chain. Is reused when creating an interchain account.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "trace": {
+              "description": "Sequence of the chain that triggered the IBC account creation `AccountTrace::Local` if the account was created locally Example: Account created on Juno which has an abstract interchain account on Osmosis, which in turn creates an interchain account on Terra -> `AccountTrace::Remote(vec![\"juno\", \"osmosis\"])`",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AccountTrace"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccountTrace": {
+          "description": "The identifier of chain that triggered the account creation",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "local"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "remote"
+              ],
+              "properties": {
+                "remote": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/ChainName"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ChainName": {
+          "description": "The name of a chain, aka the chain-id without the post-fix number. ex. `cosmoshub-4` -> `cosmoshub`, `juno-1` -> `juno`",
+          "type": "string"
+        },
+        "Message": {
+          "type": "object",
+          "required": [
+            "body",
+            "id",
+            "recipient",
+            "sender",
+            "subject",
+            "timestamp",
+            "version"
+          ],
+          "properties": {
+            "body": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "recipient": {
+              "$ref": "#/definitions/Recipient"
+            },
+            "sender": {
+              "$ref": "#/definitions/Sender"
+            },
+            "subject": {
+              "type": "string"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/Timestamp"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Namespace": {
+          "description": "Represents an Abstract namespace for modules",
+          "type": "string"
+        },
+        "Recipient": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "account"
+              ],
+              "properties": {
+                "account": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "chain": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/ChainName"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "$ref": "#/definitions/AccountId"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "namespace"
+              ],
+              "properties": {
+                "namespace": {
+                  "type": "object",
+                  "required": [
+                    "namespace"
+                  ],
+                  "properties": {
+                    "chain": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/ChainName"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "namespace": {
+                      "$ref": "#/definitions/Namespace"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Sender": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "account"
+              ],
+              "properties": {
+                "account": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "chain": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/ChainName"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "$ref": "#/definitions/AccountId"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "messages": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "MessagesResponse",
+      "type": "object",
+      "required": [
+        "messages"
+      ],
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Message"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "AccountId": {
+          "description": "Unique identifier for an account. On each chain this is unique.",
+          "type": "object",
+          "required": [
+            "seq",
+            "trace"
+          ],
+          "properties": {
+            "seq": {
+              "description": "Unique identifier for the accounts create on a local chain. Is reused when creating an interchain account.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "trace": {
+              "description": "Sequence of the chain that triggered the IBC account creation `AccountTrace::Local` if the account was created locally Example: Account created on Juno which has an abstract interchain account on Osmosis, which in turn creates an interchain account on Terra -> `AccountTrace::Remote(vec![\"juno\", \"osmosis\"])`",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AccountTrace"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccountTrace": {
+          "description": "The identifier of chain that triggered the account creation",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "local"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "remote"
+              ],
+              "properties": {
+                "remote": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/ChainName"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ChainName": {
+          "description": "The name of a chain, aka the chain-id without the post-fix number. ex. `cosmoshub-4` -> `cosmoshub`, `juno-1` -> `juno`",
+          "type": "string"
+        },
+        "Message": {
+          "type": "object",
+          "required": [
+            "body",
+            "id",
+            "recipient",
+            "sender",
+            "subject",
+            "timestamp",
+            "version"
+          ],
+          "properties": {
+            "body": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "recipient": {
+              "$ref": "#/definitions/Recipient"
+            },
+            "sender": {
+              "$ref": "#/definitions/Sender"
+            },
+            "subject": {
+              "type": "string"
+            },
+            "timestamp": {
+              "$ref": "#/definitions/Timestamp"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Namespace": {
+          "description": "Represents an Abstract namespace for modules",
+          "type": "string"
+        },
+        "Recipient": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "account"
+              ],
+              "properties": {
+                "account": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "chain": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/ChainName"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "$ref": "#/definitions/AccountId"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "namespace"
+              ],
+              "properties": {
+                "namespace": {
+                  "type": "object",
+                  "required": [
+                    "namespace"
+                  ],
+                  "properties": {
+                    "chain": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/ChainName"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "namespace": {
+                      "$ref": "#/definitions/Namespace"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Sender": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "account"
+              ],
+              "properties": {
+                "account": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "chain": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/definitions/ChainName"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "$ref": "#/definitions/AccountId"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/__output__/abstract/apps/autocompounder/Autocompounder.client.ts
+++ b/__output__/abstract/apps/autocompounder/Autocompounder.client.ts
@@ -6,7 +6,7 @@
 
 import { CamelCasedProperties } from "type-fest";
 import { SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
-import { AbstractQueryClient, AbstractAccountQueryClient, AbstractAccountClient, AppExecuteMsg, AppExecuteMsgFactory, AbstractClient } from "@abstract-money/abstract.js";
+import { AbstractQueryClient, AbstractAccountQueryClient, AbstractAccountClient, AppExecuteMsg, AppExecuteMsgFactory, AbstractClient, AbstractAccountId } from "@abstract-money/abstract.js";
 import { StdFee, Coin } from "@cosmjs/amino";
 import { Decimal, AssetEntry, BondingPeriodSelector, Duration, InstantiateMsg, ExecuteMsg, Uint128, AnsAsset, QueryMsg, MigrateMsg, Expiration, Timestamp, Uint64, ArrayOfTupleOfStringAndArrayOfClaim, Claim, ArrayOfClaim, Addr, PoolAddressBaseForAddr, AssetInfoBaseForAddr, PoolType, Config, PoolMetadata } from "./Autocompounder.types";
 import { AutocompounderQueryMsgBuilder, AutocompounderExecuteMsgBuilder } from "./Autocompounder.message-builder";
@@ -97,7 +97,13 @@ export class AutocompounderAppQueryClient implements IAutocompounderAppQueryClie
   };
   getAddress = async (): Promise<string> => {
     if (!this._moduleAddress) {
-      this._moduleAddress = await this.accountQueryClient.getModuleAddress(this.moduleId);
+      const address = await this.accountQueryClient.getModuleAddress(this.moduleId);
+
+      if (address === null) {
+        throw new Error(`Module ${this.moduleId} not installed`);
+      }
+
+      this._moduleAddress = address;
     }
 
     return this._moduleAddress!;

--- a/__output__/abstract/apps/autocompounder/Autocompounder.react-query.ts
+++ b/__output__/abstract/apps/autocompounder/Autocompounder.react-query.ts
@@ -139,7 +139,7 @@ export function useAutocompounderBalanceQuery<TData = Uint128>({
   args,
   options
 }: AutocompounderBalanceQuery<TData>) {
-  return useQuery<Uint128, Error, TData>(autocompounderQueryKeys.balance(client.moduleId, args), () => client.balance({
+  return useQuery<Uint128, Error, TData>(autocompounderQueryKeys.balance(client._moduleAddress, args), () => client.balance({
     address: args.address
   }), options);
 }
@@ -148,14 +148,14 @@ export function useAutocompounderTotalLpPositionQuery<TData = Uint128>({
   client,
   options
 }: AutocompounderTotalLpPositionQuery<TData>) {
-  return useQuery<Uint128, Error, TData>(autocompounderQueryKeys.totalLpPosition(client.moduleId), () => client.totalLpPosition(), options);
+  return useQuery<Uint128, Error, TData>(autocompounderQueryKeys.totalLpPosition(client._moduleAddress), () => client.totalLpPosition(), options);
 }
 export interface AutocompounderLatestUnbondingQuery<TData> extends AutocompounderReactQuery<Expiration, TData> {}
 export function useAutocompounderLatestUnbondingQuery<TData = Expiration>({
   client,
   options
 }: AutocompounderLatestUnbondingQuery<TData>) {
-  return useQuery<Expiration, Error, TData>(autocompounderQueryKeys.latestUnbonding(client.moduleId), () => client.latestUnbonding(), options);
+  return useQuery<Expiration, Error, TData>(autocompounderQueryKeys.latestUnbonding(client._moduleAddress), () => client.latestUnbonding(), options);
 }
 export interface AutocompounderAllClaimsQuery<TData> extends AutocompounderReactQuery<ArrayOfTupleOfStringAndArrayOfClaim, TData> {
   args: {
@@ -168,7 +168,7 @@ export function useAutocompounderAllClaimsQuery<TData = ArrayOfTupleOfStringAndA
   args,
   options
 }: AutocompounderAllClaimsQuery<TData>) {
-  return useQuery<ArrayOfTupleOfStringAndArrayOfClaim, Error, TData>(autocompounderQueryKeys.allClaims(client.moduleId, args), () => client.allClaims({
+  return useQuery<ArrayOfTupleOfStringAndArrayOfClaim, Error, TData>(autocompounderQueryKeys.allClaims(client._moduleAddress, args), () => client.allClaims({
     limit: args.limit,
     startAfter: args.startAfter
   }), options);
@@ -183,7 +183,7 @@ export function useAutocompounderClaimsQuery<TData = ArrayOfClaim>({
   args,
   options
 }: AutocompounderClaimsQuery<TData>) {
-  return useQuery<ArrayOfClaim, Error, TData>(autocompounderQueryKeys.claims(client.moduleId, args), () => client.claims({
+  return useQuery<ArrayOfClaim, Error, TData>(autocompounderQueryKeys.claims(client._moduleAddress, args), () => client.claims({
     address: args.address
   }), options);
 }
@@ -197,7 +197,7 @@ export function useAutocompounderPendingClaimsQuery<TData = Uint128>({
   args,
   options
 }: AutocompounderPendingClaimsQuery<TData>) {
-  return useQuery<Uint128, Error, TData>(autocompounderQueryKeys.pendingClaims(client.moduleId, args), () => client.pendingClaims({
+  return useQuery<Uint128, Error, TData>(autocompounderQueryKeys.pendingClaims(client._moduleAddress, args), () => client.pendingClaims({
     address: args.address
   }), options);
 }
@@ -206,7 +206,7 @@ export function useAutocompounderConfigQuery<TData = Config>({
   client,
   options
 }: AutocompounderConfigQuery<TData>) {
-  return useQuery<Config, Error, TData>(autocompounderQueryKeys.config(client.moduleId), () => client.config(), options);
+  return useQuery<Config, Error, TData>(autocompounderQueryKeys.config(client._moduleAddress), () => client.config(), options);
 }
 export interface AutocompounderBatchUnbondMutation {
   client: AutocompounderAppClient;

--- a/__output__/abstract/apps/etf-prefix/Etf.client.ts
+++ b/__output__/abstract/apps/etf-prefix/Etf.client.ts
@@ -6,7 +6,7 @@
 
 import { CamelCasedProperties } from "type-fest";
 import { SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
-import { AbstractQueryClient, AbstractAccountQueryClient, AbstractAccountClient, AppExecuteMsg, AppExecuteMsgFactory, AbstractClient } from "@abstract-money/abstract.js";
+import { AbstractQueryClient, AbstractAccountQueryClient, AbstractAccountClient, AppExecuteMsg, AppExecuteMsgFactory, AbstractClient, AbstractAccountId } from "@abstract-money/abstract.js";
 import { StdFee, Coin } from "@cosmjs/amino";
 import { Decimal, InstantiateMsg, ExecuteMsg, Uint128, AssetInfoBaseForString, AssetBaseForString, QueryMsg, MigrateMsg, StateResponse } from "./Etf.types";
 import { EtfQueryMsgBuilder, EtfExecuteMsgBuilder } from "./Etf.message-builder";
@@ -51,7 +51,13 @@ export class EtfTestQueryClient implements IEtfTestQueryClient {
   };
   getAddress = async (): Promise<string> => {
     if (!this._moduleAddress) {
-      this._moduleAddress = await this.accountQueryClient.getModuleAddress(this.moduleId);
+      const address = await this.accountQueryClient.getModuleAddress(this.moduleId);
+
+      if (address === null) {
+        throw new Error(`Module ${this.moduleId} not installed`);
+      }
+
+      this._moduleAddress = address;
     }
 
     return this._moduleAddress!;

--- a/__output__/abstract/apps/etf/Etf.client.ts
+++ b/__output__/abstract/apps/etf/Etf.client.ts
@@ -6,7 +6,7 @@
 
 import { CamelCasedProperties } from "type-fest";
 import { SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
-import { AbstractQueryClient, AbstractAccountQueryClient, AbstractAccountClient, AppExecuteMsg, AppExecuteMsgFactory, AbstractClient } from "@abstract-money/abstract.js";
+import { AbstractQueryClient, AbstractAccountQueryClient, AbstractAccountClient, AppExecuteMsg, AppExecuteMsgFactory, AbstractClient, AbstractAccountId } from "@abstract-money/abstract.js";
 import { StdFee, Coin } from "@cosmjs/amino";
 import { Decimal, InstantiateMsg, ExecuteMsg, Uint128, AssetInfoBaseForString, AssetBaseForString, QueryMsg, MigrateMsg, StateResponse } from "./Etf.types";
 import { EtfQueryMsgBuilder, EtfExecuteMsgBuilder } from "./Etf.message-builder";
@@ -51,7 +51,13 @@ export class EtfAppQueryClient implements IEtfAppQueryClient {
   };
   getAddress = async (): Promise<string> => {
     if (!this._moduleAddress) {
-      this._moduleAddress = await this.accountQueryClient.getModuleAddress(this.moduleId);
+      const address = await this.accountQueryClient.getModuleAddress(this.moduleId);
+
+      if (address === null) {
+        throw new Error(`Module ${this.moduleId} not installed`);
+      }
+
+      this._moduleAddress = address;
     }
 
     return this._moduleAddress!;

--- a/__output__/abstract/apps/etf/Etf.react-query.ts
+++ b/__output__/abstract/apps/etf/Etf.react-query.ts
@@ -43,7 +43,7 @@ export function useEtfStateQuery<TData = StateResponse>({
   client,
   options
 }: EtfStateQuery<TData>) {
-  return useQuery<StateResponse, Error, TData>(etfQueryKeys.state(client.moduleId), () => client.state(), options);
+  return useQuery<StateResponse, Error, TData>(etfQueryKeys.state(client._moduleAddress), () => client.state(), options);
 }
 export interface EtfSetFeeMutation {
   client: EtfAppClient;

--- a/packages/ts-codegen/package.json
+++ b/packages/ts-codegen/package.json
@@ -101,6 +101,6 @@
     "parse-package-name": "1.0.0",
     "rimraf": "3.0.2",
     "shelljs": "0.8.5",
-    "wasm-ast-types": "npm:@abstract-money/wasm-ast-types@0.26.3"
+    "wasm-ast-types": "file:../wasm-ast-types"
   }
 }

--- a/packages/ts-codegen/package.json
+++ b/packages/ts-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abstract-money/ts-codegen",
-  "version": "0.35.4",
+  "version": "0.35.5",
   "description": "@cosmwasm/ts-codegen converts your CosmWasm smart contracts into dev-friendly TypeScript classes so you can focus on shipping code.",
   "author": "Dan Lynch <pyramation@gmail.com>",
   "homepage": "https://github.com/cosmwasm/ts-codegen",
@@ -101,6 +101,6 @@
     "parse-package-name": "1.0.0",
     "rimraf": "3.0.2",
     "shelljs": "0.8.5",
-    "wasm-ast-types": "file:../wasm-ast-types"
+    "wasm-ast-types": "npm:@abstract-money/wasm-ast-types@0.26.4"
   }
 }

--- a/packages/wasm-ast-types/package.json
+++ b/packages/wasm-ast-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abstract-money/wasm-ast-types",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "CosmWasm TypeScript AST generation",
   "author": "Dan Lynch <pyramation@gmail.com>",
   "homepage": "https://github.com/pyramation/cosmwasm-typescript-gen/tree/master/packages/wasm-ast-types#readme",

--- a/packages/wasm-ast-types/src/abstract-app/__snapshots__/abstract-app.spec.ts.snap
+++ b/packages/wasm-ast-types/src/abstract-app/__snapshots__/abstract-app.spec.ts.snap
@@ -193,3 +193,51 @@ exports[`IAutocompounderAppQueryClient 1`] = `
   getAddress: () => Promise<string>;
 }"
 `;
+
+exports[`IbcMailClientAppClient 1`] = `
+"export class IbcMailClientAppClient extends IbcMailClientAppQueryClient implements IIbcMailClientAppClient {
+  accountClient: AbstractAccountClient;
+
+  constructor({
+    abstractClient,
+    accountId,
+    managerAddress,
+    proxyAddress,
+    moduleId
+  }: {
+    abstractClient: AbstractClient;
+    accountId: AbstractAccountId;
+    managerAddress: string;
+    proxyAddress: string;
+    moduleId: string;
+  }) {
+    super({
+      abstractQueryClient: abstractClient,
+      accountId,
+      managerAddress,
+      proxyAddress,
+      moduleId
+    });
+    this.accountClient = AbstractAccountClient.fromQueryClient(this.accountQueryClient, abstractClient);
+    this.sendMessage = this.sendMessage.bind(this);
+    this.receiveMessage = this.receiveMessage.bind(this);
+    this.updateConfig = this.updateConfig.bind(this);
+  }
+
+  sendMessage = async (params: CamelCasedProperties<Extract<ExecuteMsg, {
+    send_message: unknown;
+  }>[\\"send_message\\"]>, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+    return this._execute(IbcMailClientExecuteMsgBuilder.sendMessage(params), fee, memo, _funds);
+  };
+  receiveMessage = async (message: Message, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+    return this._execute(IbcMailClientExecuteMsgBuilder.receiveMessage(message), fee, memo, _funds);
+  };
+  updateConfig = async (fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+    return this._execute(IbcMailClientExecuteMsgBuilder.updateConfig(), fee, memo, _funds);
+  };
+  _execute = async (msg: ExecuteMsg, fee: number | StdFee | \\"auto\\" = \\"auto\\", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+    const moduleMsg: AppExecuteMsg<ExecuteMsg> = AppExecuteMsgFactory.executeApp(msg);
+    return await this.accountClient.abstract.client.execute(this.accountClient.sender, await this.getAddress(), moduleMsg, fee, memo, _funds);
+  };
+}"
+`;

--- a/packages/wasm-ast-types/src/abstract-app/__snapshots__/query-options-factory.spec.ts.snap
+++ b/packages/wasm-ast-types/src/abstract-app/__snapshots__/query-options-factory.spec.ts.snap
@@ -67,6 +67,33 @@ exports[`etf 1`] = `
 });"
 `;
 
+exports[`ibcmailClientQueryMsg 1`] = `
+"export const ibcMailClientQueries = createQueryKeys(\\"IbcMailClient\\", {
+  listMessages: (queryClient: AutocompounderQueryClient, params: CamelCasedProperties<Extract<QueryMsg, {
+    list_messages: unknown;
+  }>[\\"list_messages\\"]>) => ({
+    queryKey: [{
+      address: queryClient.contractAddress
+    }, params],
+    queryFn: ctx => queryClient.listMessages(params)
+  }),
+  messages: (queryClient: AutocompounderQueryClient, params: CamelCasedProperties<Extract<QueryMsg, {
+    messages: unknown;
+  }>[\\"messages\\"]>) => ({
+    queryKey: [{
+      address: queryClient.contractAddress
+    }, params],
+    queryFn: ctx => queryClient.messages(params)
+  }),
+  config: (queryClient: AutocompounderQueryClient) => ({
+    queryKey: [{
+      address: queryClient.contractAddress
+    }],
+    queryFn: ctx => queryClient.config()
+  })
+});"
+`;
+
 exports[`queryMsg 1`] = `
 "export const contractQueries = createQueryKeys(\\"Contract\\", {
   ownerOf: (queryClient: AutocompounderQueryClient, params: CamelCasedProperties<Extract<QueryMsg, {

--- a/packages/wasm-ast-types/src/abstract-app/abstract-app.spec.ts
+++ b/packages/wasm-ast-types/src/abstract-app/abstract-app.spec.ts
@@ -1,4 +1,5 @@
 import autocompounder_schema from '../../../../__fixtures__/abstract/apps/autocompounder.json';
+import ibcmailclient_schema from '../../../../__fixtures__/abstract/apps/ibcmail/client.json';
 import { expectCode, makeContext } from '../../test-utils';
 import {
   createAppExecuteClass,
@@ -8,7 +9,7 @@ import {
 } from './abstract-app';
 
 it('IAutocompounderAppQueryClient', () => {
-  const ctx = makeContext(autocompounder_schema);
+  const ctx = makeContext(autocompounder_schema.query);
 
   expectCode(
     createAppQueryInterface(
@@ -21,7 +22,7 @@ it('IAutocompounderAppQueryClient', () => {
 });
 
 it('AutocompounderAppQueryClient', () => {
-  const ctx = makeContext(autocompounder_schema);
+  const ctx = makeContext(autocompounder_schema.query);
 
   expectCode(
     createAppQueryClass(
@@ -35,7 +36,7 @@ it('AutocompounderAppQueryClient', () => {
 });
 
 it('IAutocompounderAppClient', () => {
-  const ctx = makeContext(autocompounder_schema);
+  const ctx = makeContext(autocompounder_schema.execute);
 
   expectCode(
     createAppExecuteInterface(
@@ -49,7 +50,7 @@ it('IAutocompounderAppClient', () => {
 });
 
 it('AutocompounderAppClient', () => {
-  const ctx = makeContext(autocompounder_schema);
+  const ctx = makeContext(autocompounder_schema.execute);
 
   expectCode(
     createAppExecuteClass(
@@ -59,6 +60,21 @@ it('AutocompounderAppClient', () => {
       'IAutocompounderAppClient',
       'AutocompounderAppQueryClient',
       autocompounder_schema.execute
+    )
+  );
+});
+
+it('IbcMailClientAppClient', () => {
+  const ctx = makeContext(ibcmailclient_schema.execute);
+
+  expectCode(
+    createAppExecuteClass(
+      ctx,
+      'IbcMailClient',
+      'IbcMailClientAppClient',
+      'IIbcMailClientAppClient',
+      'IbcMailClientAppQueryClient',
+      ibcmailclient_schema.execute
     )
   );
 });

--- a/packages/wasm-ast-types/src/abstract-app/abstract-app.ts
+++ b/packages/wasm-ast-types/src/abstract-app/abstract-app.ts
@@ -66,903 +66,924 @@ const ABSTRACT_ACCOUNT_ID = 'AbstractAccountId';
 const ABSTRACT_ACCOUNT_QUERY_CLIENT = 'AbstractAccountQueryClient';
 const ADDRESS_GETTER_FN_NAME = 'getAddress';
 
-function extractCamelcasedMethodParams(
-  type: 'ExecuteMsg' | 'QueryMsg',
-  jsonschema,
-  underscoreName: string
-) {
-  const methadParams = Object.keys(
-    jsonschema.properties[underscoreName]?.properties ?? {}
-  );
-
-  // the actual type of the ref
-  const methodParam = t.identifier('params');
-  methodParam.typeAnnotation = createExtractTypeAnnotation(
-    underscoreName,
-    type
-  );
-
-  const parameters = methadParams.length ? [methodParam] : [];
-  return parameters;
-}
-
 /**
- * The address and connect methods in the interface.
+ *
+ * @param type
+ * @param jsonschema
+ * @param underscoreName
+ * @returns
  */
-const staticQueryInterfaceMethods = (connectedAppClientName: string) => {
-  return [
-    t.tsPropertySignature(
-      t.identifier('connectSigningClient'),
-      t.tsTypeAnnotation(
-        t.tsFunctionType(
-          undefined,
-          // params
-          [
-            identifier(
-              'signingClient',
-              t.tsTypeAnnotation(
-                t.tsTypeReference(t.identifier('SigningCosmWasmClient'))
-              )
-            ),
-            identifier('address', t.tsTypeAnnotation(t.tsStringKeyword()))
-          ],
-          // Return the connected app client
-          t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier(connectedAppClientName))
-          )
-        )
-      )
-    ),
-    t.tsPropertySignature(
-      t.identifier(ADDRESS_GETTER_FN_NAME),
-      t.tsTypeAnnotation(
-        t.tsFunctionType(
-          undefined,
-          [],
-          // return
-          promiseTypeAnnotation('string')
-        )
-      )
-    )
-  ];
-};
-
-// TODO: there might not be any execute methods, in which case we wouldn't need the connect method
-export const createAppQueryInterface = (
+function extractCamelcasedMethodParams(
   context: RenderContext,
-  interfaceClassName: string,
-  mutClassName: string,
-  queryMsg: QueryMsg
-) => {
-  context.addUtils(['SigningCosmWasmClient', ABSTRACT_QUERY_CLIENT]);
-
-  const methods = getMessageProperties(queryMsg).map((jsonschema) => {
-    const underscoreName = Object.keys(jsonschema.properties)[0];
-    const methodName = camel(underscoreName);
-    const responseType = getResponseType(context, underscoreName);
-    const parameters = extractCamelcasedMethodParams(
-      'QueryMsg',
-      jsonschema,
-      underscoreName
-    );
-
-    const func = {
-      type: 'TSFunctionType',
-      typeAnnotation: promiseTypeAnnotation(responseType),
-      parameters
-    };
-
-    return t.tSPropertySignature(
-      t.identifier(methodName),
-      // @ts-ignore
-      t.tsTypeAnnotation(func)
-    );
-  });
-
-  return t.exportNamedDeclaration(
-    t.tsInterfaceDeclaration(
-      t.identifier(interfaceClassName),
-      null,
-      [],
-      t.tSInterfaceBody([
-        t.tSPropertySignature(
-          CLASS_VARS.moduleId,
-          t.tsTypeAnnotation(t.tsStringKeyword())
-        ),
-        t.tSPropertySignature(
-          CLASS_VARS.accountQueryClient,
-          t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_QUERY_CLIENT))
-          )
-        ),
-        t.tSPropertySignature(
-          CLASS_VARS._moduleAddress,
-          t.tsTypeAnnotation(
-            t.tsUnionType([t.tsStringKeyword(), t.tsUndefinedKeyword()])
-          )
-        ),
-        ...methods,
-        ...staticQueryInterfaceMethods(mutClassName)
-      ])
-    )
+  type: 'ExecuteMsg' | 'QueryMsg' | 'Object',
+  jsonschema,
+  underscoreName: string): Array<t.Identifier> {
+  const msgSchema = jsonschema.properties[underscoreName];
+  const methodParams = Object.keys(
+    msgSchema?.properties ?? {}
   );
-};
 
-// TODO: private
-const QUERY_APP_FN = t.classProperty(
-  t.identifier('_query'),
-  arrowFunctionExpression(
-    [
-      identifier(
-        'queryMsg',
-        t.tsTypeAnnotation(t.tsTypeReference(t.identifier('QueryMsg')))
-      )
-    ],
-    t.blockStatement(
-      [
-        t.returnStatement(
-          t.callExpression(
-            t.memberExpression(
-              t.memberExpression(
-                t.thisExpression(),
-                CLASS_VARS.accountQueryClient
-              ),
-              t.identifier('queryModule')
-            ),
+  // Logic duplicated from createTypedObjectParams
+  if (!methodParams.length) {
+    // is there a ref?
+    if (msgSchema.$ref) {
+      const obj = context.refLookup(msgSchema.$ref);
+      // If there is a oneOf, then we need to create a type for it
+      if (obj) {
+        // the actual type of the ref
+        const refType = msgSchema.$ref.split('/').pop();
+        const refName = camel(refType);
+        const id = t.identifier(refName);
+        id.typeAnnotation = t.tsTypeAnnotation(t.tsTypeReference(t.identifier(refType)));
+        // return the parameter
+        return [id];
+      } else {
+        console.error(`Could not find $ref for ${JSON.stringify(msgSchema)}, ${JSON.stringify(context.schema)}`);
+        return []
+      }
+    }
+  }
+
+    // the actual type of the ref
+    const methodParam = t.identifier('params');
+    methodParam.typeAnnotation = createExtractTypeAnnotation(
+      underscoreName,
+      type
+    );
+
+    const parameters = methodParams.length ? [methodParam] : [];
+    return parameters;
+  }
+
+  /**
+   * The address and connect methods in the interface.
+   */
+  const staticQueryInterfaceMethods = (connectedAppClientName: string) => {
+    return [
+      t.tsPropertySignature(
+        t.identifier('connectSigningClient'),
+        t.tsTypeAnnotation(
+          t.tsFunctionType(
+            undefined,
+            // params
             [
-              t.objectExpression([
-                t.objectProperty(
-                  t.identifier('moduleId'),
-                  t.memberExpression(t.thisExpression(), CLASS_VARS.moduleId)
-                ),
-                t.objectProperty(
-                  t.identifier('moduleType'),
-                  t.stringLiteral('app')
-                ),
-                shorthandProperty('queryMsg')
-              ])
-            ]
-          )
-        )
-      ],
-      []
-    ),
-    // TODO: better than any
-    promiseTypeAnnotation('any'),
-    true
-  )
-);
-
-export const createAppExecuteInterface = (
-  context: RenderContext,
-  interfaceClassName: string,
-  mutClassName: string,
-  extendsClassName,
-  executeMsg: ExecuteMsg
-): t.ExportNamedDeclaration => {
-  context.addUtils([
-    'SigningCosmWasmClient',
-    ABSTRACT_ACCOUNT_CLIENT,
-    'ExecuteResult',
-    'AppExecuteMsg',
-    'AppExecuteMsgFactory'
-  ]);
-
-  const methods = getMessageProperties(executeMsg).map((jsonschema) => {
-    const underscoreName = Object.keys(jsonschema.properties)[0];
-    const methodName = camel(underscoreName);
-    const parameters = extractCamelcasedMethodParams(
-      'ExecuteMsg',
-      jsonschema,
-      underscoreName
-    );
-
-    const func = {
-      type: 'TSFunctionType',
-      typeAnnotation: promiseTypeAnnotation('ExecuteResult'),
-      parameters: parameters
-        ? [...parameters, ...OPTIONAL_FIXED_EXECUTE_PARAMS]
-        : OPTIONAL_FIXED_EXECUTE_PARAMS
-    };
-
-    return t.tSPropertySignature(
-      t.identifier(methodName),
-      // @ts-ignore
-      t.tsTypeAnnotation(func)
-    );
-  });
-
-  const extendsDeclaration = extendsClassName
-    ? [t.tSExpressionWithTypeArguments(t.identifier(extendsClassName))]
-    : [];
-
-  return t.exportNamedDeclaration(
-    t.tsInterfaceDeclaration(
-      t.identifier(interfaceClassName),
-      null,
-      extendsDeclaration,
-      t.tSInterfaceBody([
-        t.tSPropertySignature(
-          CLASS_VARS.accountClient,
-          t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_CLIENT))
-          )
-        ),
-        ...methods
-      ])
-    )
-  );
-};
-
-const EXECUTE_APP_FN = t.classProperty(
-  t.identifier('_execute'),
-  arrowFunctionExpression(
-    [
-      identifier(
-        'msg',
-        t.tsTypeAnnotation(t.tsTypeReference(t.identifier('ExecuteMsg')))
-      ),
-      ...CONSTANT_EXEC_PARAMS
-    ],
-    t.blockStatement(
-      [
-        t.variableDeclaration('const', [
-          t.variableDeclarator(
-            identifier(
-              'moduleMsg',
-              t.tsTypeAnnotation(
-                t.tSTypeReference(
-                  t.identifier('AppExecuteMsg'),
-                  t.tsTypeParameterInstantiation([
-                    t.tsTypeReference(t.identifier('ExecuteMsg'))
-                  ])
+              identifier(
+                'signingClient',
+                t.tsTypeAnnotation(
+                  t.tsTypeReference(t.identifier('SigningCosmWasmClient'))
                 )
-              )
-            ),
-            t.callExpression(
-              t.memberExpression(
-                t.identifier('AppExecuteMsgFactory'),
-                t.identifier('executeApp')
               ),
-              [t.identifier('msg')]
-            )
-          )
-        ]),
-        t.returnStatement(
-          t.awaitExpression(
-            t.callExpression(
-              t.memberExpression(
-                t.memberExpression(
-                  t.memberExpression(
-                    t.memberExpression(
-                      t.thisExpression(),
-                      t.identifier('accountClient')
-                    ),
-                    t.identifier('abstract')
-                  ),
-                  t.identifier('client')
-                ),
-                t.identifier('execute')
-              ),
-              [
-                t.memberExpression(
-                  t.memberExpression(
-                    t.thisExpression(),
-
-                    t.identifier('accountClient')
-                  ),
-                  t.identifier('sender')
-                ),
-                // get this module address
-                t.awaitExpression(
-                  t.callExpression(
-                    t.memberExpression(
-                      t.thisExpression(),
-                      t.identifier(ADDRESS_GETTER_FN_NAME)
-                    ),
-                    []
-                  )
-                ),
-                t.identifier('moduleMsg'),
-                t.identifier('fee'),
-                t.identifier('memo'),
-                t.identifier('_funds')
-              ]
+              identifier('address', t.tsTypeAnnotation(t.tsStringKeyword()))
+            ],
+            // Return the connected app client
+            t.tsTypeAnnotation(
+              t.tsTypeReference(t.identifier(connectedAppClientName))
             )
           )
         )
-      ],
-      []
-    ),
-    // return
-    promiseTypeAnnotation('ExecuteResult'),
-    // async
-    true
-  )
-);
-
-export const createAppQueryClass = (
-  context: RenderContext,
-  _moduleName: string,
-  className: string,
-  implementsClassName: string,
-  queryMsg: QueryMsg
-): t.ExportNamedDeclaration => {
-  const moduleName = pascal(_moduleName);
-
-  context.addUtils([ABSTRACT_QUERY_CLIENT, ABSTRACT_ACCOUNT_QUERY_CLIENT]);
-
-  const propertyNames = getMessageProperties(queryMsg)
-    .map((method) => Object.keys(method.properties)?.[0])
-    .filter(Boolean);
-
-  const bindings = propertyNames.map(camel).map(bindMethod);
-
-  const methods = getMessageProperties(queryMsg).map((schema) => {
-    return createAppQueryMethod(context, moduleName, schema);
-  });
-
-  methods.push(ADDRESS_ACCESSOR_FN);
-  methods.push(
-    connectSigningClientMethod(
-      `${moduleName}${context.options.abstractApp?.clientPrefix ?? ''}Client`
-    )
-  );
-  methods.push(QUERY_APP_FN);
-
-  return t.exportNamedDeclaration(
-    classDeclaration(
-      className,
-      [
-        // client
-        classProperty(
-          'accountQueryClient',
-          t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_QUERY_CLIENT))
+      ),
+      t.tsPropertySignature(
+        t.identifier(ADDRESS_GETTER_FN_NAME),
+        t.tsTypeAnnotation(
+          t.tsFunctionType(
+            undefined,
+            [],
+            // return
+            promiseTypeAnnotation('string')
           )
-        ),
+        )
+      )
+    ];
+  };
 
-        // moduleId
-        classProperty('moduleId', t.tsTypeAnnotation(t.tsStringKeyword())),
+  // TODO: there might not be any execute methods, in which case we wouldn't need the connect method
+  export const createAppQueryInterface = (
+    context: RenderContext,
+    interfaceClassName: string,
+    mutClassName: string,
+    queryMsg: QueryMsg
+  ) => {
+    context.addUtils(['SigningCosmWasmClient', ABSTRACT_QUERY_CLIENT]);
 
-        // _moduleAddress
-        {
-          ...classProperty(
-            '_moduleAddress',
+    const methods = getMessageProperties(queryMsg).map((jsonschema) => {
+      const underscoreName = Object.keys(jsonschema.properties)[0];
+      const methodName = camel(underscoreName);
+      const responseType = getResponseType(context, underscoreName);
+      const parameters = extractCamelcasedMethodParams(context, 'QueryMsg', jsonschema, underscoreName);
+
+      const func = {
+        type: 'TSFunctionType',
+        typeAnnotation: promiseTypeAnnotation(responseType),
+        parameters
+      };
+
+      return t.tSPropertySignature(
+        t.identifier(methodName),
+        // @ts-ignore
+        t.tsTypeAnnotation(func)
+      );
+    });
+
+    return t.exportNamedDeclaration(
+      t.tsInterfaceDeclaration(
+        t.identifier(interfaceClassName),
+        null,
+        [],
+        t.tSInterfaceBody([
+          t.tSPropertySignature(
+            CLASS_VARS.moduleId,
+            t.tsTypeAnnotation(t.tsStringKeyword())
+          ),
+          t.tSPropertySignature(
+            CLASS_VARS.accountQueryClient,
+            t.tsTypeAnnotation(
+              t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_QUERY_CLIENT))
+            )
+          ),
+          t.tSPropertySignature(
+            CLASS_VARS._moduleAddress,
             t.tsTypeAnnotation(
               t.tsUnionType([t.tsStringKeyword(), t.tsUndefinedKeyword()])
             )
           ),
-          visibility: 'private'
-        },
+          ...methods,
+          ...staticQueryInterfaceMethods(mutClassName)
+        ])
+      )
+    );
+  };
 
-        // constructor
-        t.classMethod(
-          'constructor',
-          t.identifier('constructor'),
-          [
-            autoTypedObjectPattern([
-              shorthandProperty(
-                'abstractQueryClient',
-                t.tsTypeAnnotation(
-                  t.tsTypeReference(t.identifier(ABSTRACT_QUERY_CLIENT))
-                )
-              ),
-              shorthandProperty(
-                'accountId',
-                t.tsTypeAnnotation(
-                  t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_ID))
-                )
-              ),
-              shorthandProperty(
-                'managerAddress',
-                t.tsTypeAnnotation(t.tsStringKeyword())
-              ),
-              shorthandProperty(
-                'proxyAddress',
-                t.tsTypeAnnotation(t.tsStringKeyword())
-              ),
-              shorthandProperty(
-                'moduleId',
-                t.tsTypeAnnotation(t.tsStringKeyword())
-              )
-            ])
-          ],
-          t.blockStatement([
-            t.expressionStatement(
-              t.assignmentExpression(
-                '=',
+  // TODO: private
+  const QUERY_APP_FN = t.classProperty(
+    t.identifier('_query'),
+    arrowFunctionExpression(
+      [
+        identifier(
+          'queryMsg',
+          t.tsTypeAnnotation(t.tsTypeReference(t.identifier('QueryMsg')))
+        )
+      ],
+      t.blockStatement(
+        [
+          t.returnStatement(
+            t.callExpression(
+              t.memberExpression(
                 t.memberExpression(
                   t.thisExpression(),
                   CLASS_VARS.accountQueryClient
                 ),
-                t.newExpression(t.identifier(ABSTRACT_ACCOUNT_QUERY_CLIENT), [
+                t.identifier('queryModule')
+              ),
+              [
+                t.objectExpression([
+                  t.objectProperty(
+                    t.identifier('moduleId'),
+                    t.memberExpression(t.thisExpression(), CLASS_VARS.moduleId)
+                  ),
+                  t.objectProperty(
+                    t.identifier('moduleType'),
+                    t.stringLiteral('app')
+                  ),
+                  shorthandProperty('queryMsg')
+                ])
+              ]
+            )
+          )
+        ],
+        []
+      ),
+      // TODO: better than any
+      promiseTypeAnnotation('any'),
+      true
+    )
+  );
+
+  export const createAppExecuteInterface = (
+    context: RenderContext,
+    interfaceClassName: string,
+    mutClassName: string,
+    extendsClassName,
+    executeMsg: ExecuteMsg
+  ): t.ExportNamedDeclaration => {
+    context.addUtils([
+      'SigningCosmWasmClient',
+      ABSTRACT_ACCOUNT_CLIENT,
+      'ExecuteResult',
+      'AppExecuteMsg',
+      'AppExecuteMsgFactory'
+    ]);
+
+    const methods = getMessageProperties(executeMsg).map((jsonschema) => {
+      const underscoreName = Object.keys(jsonschema.properties)[0];
+      const methodName = camel(underscoreName);
+      const parameters = extractCamelcasedMethodParams(context, 'ExecuteMsg', jsonschema, underscoreName);
+
+      const func = {
+        type: 'TSFunctionType',
+        typeAnnotation: promiseTypeAnnotation('ExecuteResult'),
+        parameters: parameters
+          ? [...parameters, ...OPTIONAL_FIXED_EXECUTE_PARAMS]
+          : OPTIONAL_FIXED_EXECUTE_PARAMS
+      };
+
+      return t.tSPropertySignature(
+        t.identifier(methodName),
+        // @ts-ignore
+        t.tsTypeAnnotation(func)
+      );
+    });
+
+    const extendsDeclaration = extendsClassName
+      ? [t.tSExpressionWithTypeArguments(t.identifier(extendsClassName))]
+      : [];
+
+    return t.exportNamedDeclaration(
+      t.tsInterfaceDeclaration(
+        t.identifier(interfaceClassName),
+        null,
+        extendsDeclaration,
+        t.tSInterfaceBody([
+          t.tSPropertySignature(
+            CLASS_VARS.accountClient,
+            t.tsTypeAnnotation(
+              t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_CLIENT))
+            )
+          ),
+          ...methods
+        ])
+      )
+    );
+  };
+
+  const EXECUTE_APP_FN = t.classProperty(
+    t.identifier('_execute'),
+    arrowFunctionExpression(
+      [
+        identifier(
+          'msg',
+          t.tsTypeAnnotation(t.tsTypeReference(t.identifier('ExecuteMsg')))
+        ),
+        ...CONSTANT_EXEC_PARAMS
+      ],
+      t.blockStatement(
+        [
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              identifier(
+                'moduleMsg',
+                t.tsTypeAnnotation(
+                  t.tSTypeReference(
+                    t.identifier('AppExecuteMsg'),
+                    t.tsTypeParameterInstantiation([
+                      t.tsTypeReference(t.identifier('ExecuteMsg'))
+                    ])
+                  )
+                )
+              ),
+              t.callExpression(
+                t.memberExpression(
+                  t.identifier('AppExecuteMsgFactory'),
+                  t.identifier('executeApp')
+                ),
+                [t.identifier('msg')]
+              )
+            )
+          ]),
+          t.returnStatement(
+            t.awaitExpression(
+              t.callExpression(
+                t.memberExpression(
+                  t.memberExpression(
+                    t.memberExpression(
+                      t.memberExpression(
+                        t.thisExpression(),
+                        t.identifier('accountClient')
+                      ),
+                      t.identifier('abstract')
+                    ),
+                    t.identifier('client')
+                  ),
+                  t.identifier('execute')
+                ),
+                [
+                  t.memberExpression(
+                    t.memberExpression(
+                      t.thisExpression(),
+
+                      t.identifier('accountClient')
+                    ),
+                    t.identifier('sender')
+                  ),
+                  // get this module address
+                  t.awaitExpression(
+                    t.callExpression(
+                      t.memberExpression(
+                        t.thisExpression(),
+                        t.identifier(ADDRESS_GETTER_FN_NAME)
+                      ),
+                      []
+                    )
+                  ),
+                  t.identifier('moduleMsg'),
+                  t.identifier('fee'),
+                  t.identifier('memo'),
+                  t.identifier('_funds')
+                ]
+              )
+            )
+          )
+        ],
+        []
+      ),
+      // return
+      promiseTypeAnnotation('ExecuteResult'),
+      // async
+      true
+    )
+  );
+
+  export const createAppQueryClass = (
+    context: RenderContext,
+    _moduleName: string,
+    className: string,
+    implementsClassName: string,
+    queryMsg: QueryMsg
+  ): t.ExportNamedDeclaration => {
+    const moduleName = pascal(_moduleName);
+
+    context.addUtils([ABSTRACT_QUERY_CLIENT, ABSTRACT_ACCOUNT_QUERY_CLIENT]);
+
+    const propertyNames = getMessageProperties(queryMsg)
+      .map((method) => Object.keys(method.properties)?.[0])
+      .filter(Boolean);
+
+    const bindings = propertyNames.map(camel).map(bindMethod);
+
+    const methods = getMessageProperties(queryMsg).map((schema) => {
+      return createAppQueryMethod(context, moduleName, schema);
+    });
+
+    methods.push(ADDRESS_ACCESSOR_FN);
+    methods.push(
+      connectSigningClientMethod(
+        `${moduleName}${context.options.abstractApp?.clientPrefix ?? ''}Client`
+      )
+    );
+    methods.push(QUERY_APP_FN);
+
+    return t.exportNamedDeclaration(
+      classDeclaration(
+        className,
+        [
+          // client
+          classProperty(
+            'accountQueryClient',
+            t.tsTypeAnnotation(
+              t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_QUERY_CLIENT))
+            )
+          ),
+
+          // moduleId
+          classProperty('moduleId', t.tsTypeAnnotation(t.tsStringKeyword())),
+
+          // _moduleAddress
+          {
+            ...classProperty(
+              '_moduleAddress',
+              t.tsTypeAnnotation(
+                t.tsUnionType([t.tsStringKeyword(), t.tsUndefinedKeyword()])
+              )
+            ),
+            visibility: 'private'
+          },
+
+          // constructor
+          t.classMethod(
+            'constructor',
+            t.identifier('constructor'),
+            [
+              autoTypedObjectPattern([
+                shorthandProperty(
+                  'abstractQueryClient',
+                  t.tsTypeAnnotation(
+                    t.tsTypeReference(t.identifier(ABSTRACT_QUERY_CLIENT))
+                  )
+                ),
+                shorthandProperty(
+                  'accountId',
+                  t.tsTypeAnnotation(
+                    t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_ID))
+                  )
+                ),
+                shorthandProperty(
+                  'managerAddress',
+                  t.tsTypeAnnotation(t.tsStringKeyword())
+                ),
+                shorthandProperty(
+                  'proxyAddress',
+                  t.tsTypeAnnotation(t.tsStringKeyword())
+                ),
+                shorthandProperty(
+                  'moduleId',
+                  t.tsTypeAnnotation(t.tsStringKeyword())
+                )
+              ])
+            ],
+            t.blockStatement([
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.memberExpression(
+                    t.thisExpression(),
+                    CLASS_VARS.accountQueryClient
+                  ),
+                  t.newExpression(t.identifier(ABSTRACT_ACCOUNT_QUERY_CLIENT), [
+                    t.objectExpression([
+                      t.objectProperty(
+                        t.identifier('abstract'),
+                        t.identifier('abstractQueryClient'),
+                        false,
+                        true
+                      ),
+                      shorthandProperty('accountId'),
+                      shorthandProperty('managerAddress'),
+                      shorthandProperty('proxyAddress')
+                    ])
+                  ])
+                )
+              ),
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.memberExpression(
+                    t.thisExpression(),
+                    t.identifier('moduleId')
+                  ),
+                  t.identifier('moduleId')
+                )
+              ),
+              ...bindings
+            ])
+          ),
+
+          ...methods
+        ],
+        [t.tSExpressionWithTypeArguments(t.identifier(implementsClassName))]
+      )
+    );
+  };
+
+  const ADDRESS_ACCESSOR_FN = t.classProperty(
+    t.identifier(ADDRESS_GETTER_FN_NAME),
+    arrowFunctionExpression(
+      [],
+      t.blockStatement([
+        t.ifStatement(
+          t.unaryExpression(
+            '!',
+            t.memberExpression(t.thisExpression(), CLASS_VARS._moduleAddress)
+          ),
+          t.blockStatement([
+            t.variableDeclaration(
+              'const',
+              [
+                t.variableDeclarator(
+                  t.identifier('address'),
+                  t.awaitExpression(
+                    t.callExpression(
+                      t.memberExpression(
+                        t.memberExpression(
+                          t.thisExpression(),
+                          CLASS_VARS.accountQueryClient
+                        ),
+                        t.identifier('getModuleAddress')
+                      ),
+                      [
+                        t.memberExpression(
+                          t.thisExpression(),
+                          t.identifier('moduleId')
+                        )
+                      ]
+                    )
+                  )
+                )
+              ]
+            ),
+            t.ifStatement(
+              t.binaryExpression(
+                '===',
+                t.identifier('address'),
+                t.nullLiteral()
+              ),
+              t.blockStatement([
+                t.throwStatement(
+                  t.newExpression(
+                    t.identifier('Error'),
+                    [t.templateLiteral(
+                      [
+                        t.templateElement({ raw: 'Module ', cooked: 'Module ' }, false),
+                        t.templateElement({ raw: ' not installed', cooked: ' not installed' }, true)
+                      ],
+                      [t.memberExpression(t.thisExpression(), t.identifier('moduleId'))]
+                    )]
+                  )
+                )
+              ])
+            ),
+            t.expressionStatement(
+              t.assignmentExpression(
+                '=',
+                t.memberExpression(t.thisExpression(), CLASS_VARS._moduleAddress),
+                t.identifier('address')
+              )
+            )
+          ])
+        ),
+        t.returnStatement(
+          // The address must be available because we just retrieved it
+          t.memberExpression(t.thisExpression(), t.identifier('_moduleAddress!'))
+        )
+      ]),
+      promiseTypeAnnotation('string'),
+      true
+    )
+  );
+
+
+  const connectSigningClientMethod = (mutClientName: string) => {
+    return t.classProperty(
+      t.identifier('connectSigningClient'),
+      arrowFunctionExpression(
+        [
+          identifier(
+            'signingClient',
+            t.tsTypeAnnotation(
+              t.tsTypeReference(t.identifier('SigningCosmWasmClient'))
+            )
+          ),
+          identifier('address', t.tsTypeAnnotation(t.tsStringKeyword()))
+        ],
+        t.blockStatement([
+          t.returnStatement(
+            t.newExpression(t.identifier(mutClientName), [
+              t.objectExpression([
+                t.objectProperty(
+                  t.identifier('accountId'),
+                  t.memberExpression(
+                    t.memberExpression(
+                      t.thisExpression(),
+                      CLASS_VARS.accountQueryClient
+                    ),
+                    t.identifier('accountId')
+                  )
+                ),
+                t.objectProperty(
+                  t.identifier('managerAddress'),
+                  t.memberExpression(
+                    t.memberExpression(
+                      t.thisExpression(),
+                      CLASS_VARS.accountQueryClient
+                    ),
+                    t.identifier('managerAddress')
+                  )
+                ),
+                t.objectProperty(
+                  t.identifier('proxyAddress'),
+                  t.memberExpression(
+                    t.memberExpression(
+                      t.thisExpression(),
+                      CLASS_VARS.accountQueryClient
+                    ),
+                    t.identifier('proxyAddress')
+                  )
+                ),
+                t.objectProperty(
+                  t.identifier('moduleId'),
+                  t.memberExpression(t.thisExpression(), t.identifier('moduleId'))
+                ),
+                t.objectProperty(
+                  t.identifier('abstractClient'),
+                  t.callExpression(
+                    t.memberExpression(
+                      t.memberExpression(
+                        t.memberExpression(
+                          t.thisExpression(),
+                          CLASS_VARS.accountQueryClient
+                        ),
+                        t.identifier('abstract')
+                      ),
+                      t.identifier('connectSigningClient')
+                    ),
+                    [t.identifier('signingClient'), t.identifier('address')]
+                  )
+                )
+              ])
+            ])
+          )
+        ]),
+        t.tsTypeAnnotation(t.tsTypeReference(t.identifier(mutClientName)))
+      )
+    );
+  };
+
+  /*
+    public pendingClaims = async (
+      params: ExtractCamelizedParams<AutocompounderQueryMsg, 'pending_claims'>
+    ): Promise<Uint128> => {
+      return this._query(AutocompounderQueryMsgBuilder.pendingClaims(params))
+    }
+   */
+  const createAppQueryMethod = (
+    context: RenderContext,
+    moduleName: string,
+    schema: any
+  ) => {
+    const underscoreName = Object.keys(schema.properties)[0];
+    const methodName = camel(underscoreName);
+    const responseType = getResponseType(context, underscoreName);
+
+    const queryParams = Object.keys(
+      schema.properties[underscoreName]?.properties ?? {}
+    );
+
+    // the actual type of the ref
+    const methodParam = t.identifier('params');
+    methodParam.typeAnnotation = createExtractTypeAnnotation(
+      underscoreName,
+      moduleName
+    );
+
+    const parameters = extractCamelcasedMethodParams(context, 'QueryMsg', schema, underscoreName);
+
+    return t.classProperty(
+      t.identifier(methodName),
+      arrowFunctionExpression(
+        parameters,
+        t.blockStatement([
+          t.returnStatement(
+            t.callExpression(
+              t.memberExpression(t.thisExpression(), t.identifier('_query')),
+              [
+                t.callExpression(
+                  t.memberExpression(
+                    t.identifier(`${moduleName}QueryMsgBuilder`),
+                    t.identifier(methodName)
+                  ),
+                  parameters
+                )
+              ]
+            )
+          )
+        ]),
+        promiseTypeAnnotation(responseType),
+        true
+      )
+    );
+  };
+
+  export const createAppExecuteClass = (
+    context: RenderContext,
+    uncheckedModuleName: string,
+    className: string,
+    implementsClassName: string,
+    extendsClassName: string,
+    execMsg: ExecuteMsg
+  ): ExportNamedDeclaration => {
+    const moduleName = pascal(uncheckedModuleName);
+
+    context.addUtils([
+      ABSTRACT_ACCOUNT_CLIENT,
+      'StdFee',
+      'Coin',
+      ABSTRACT_CLIENT,
+      ABSTRACT_ACCOUNT_ID
+    ]);
+
+    const propertyNames = getMessageProperties(execMsg)
+      .map((method) => Object.keys(method.properties)?.[0])
+      .filter(Boolean);
+
+    const bindings = propertyNames.map(camel).map(bindMethod);
+
+    const methods = getMessageProperties(execMsg).map((schema) => {
+      return createAppExecMethod(context, moduleName, schema);
+    });
+
+    methods.push(EXECUTE_APP_FN);
+
+    return t.exportNamedDeclaration(
+      classDeclaration(
+        className,
+        [
+          // client
+          classProperty(
+            'accountClient',
+            t.tsTypeAnnotation(
+              t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_CLIENT))
+            )
+          ),
+
+          // constructor
+          t.classMethod(
+            'constructor',
+            t.identifier('constructor'),
+            // TODO: typing
+            [
+              autoTypedObjectPattern([
+                shorthandProperty(
+                  'abstractClient',
+                  t.tsTypeAnnotation(
+                    t.tsTypeReference(t.identifier(ABSTRACT_CLIENT))
+                  )
+                ),
+                shorthandProperty(
+                  'accountId',
+                  t.tsTypeAnnotation(
+                    t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_ID))
+                  )
+                ),
+                shorthandProperty(
+                  'managerAddress',
+                  t.tsTypeAnnotation(t.tsStringKeyword())
+                ),
+                shorthandProperty(
+                  'proxyAddress',
+                  t.tsTypeAnnotation(t.tsStringKeyword())
+                ),
+                shorthandProperty(
+                  'moduleId',
+                  t.tsTypeAnnotation(t.tsStringKeyword())
+                )
+              ])
+            ],
+            t.blockStatement([
+              t.expressionStatement(
+                // TODO!
+                t.callExpression(t.super(), [
                   t.objectExpression([
                     t.objectProperty(
-                      t.identifier('abstract'),
-                      t.identifier('abstractQueryClient'),
+                      identifier('abstractQueryClient', undefined),
+                      t.identifier('abstractClient'),
                       false,
                       true
                     ),
                     shorthandProperty('accountId'),
                     shorthandProperty('managerAddress'),
-                    shorthandProperty('proxyAddress')
+                    shorthandProperty('proxyAddress'),
+                    shorthandProperty('moduleId')
                   ])
                 ])
-              )
-            ),
-            t.expressionStatement(
-              t.assignmentExpression(
-                '=',
-                t.memberExpression(
-                  t.thisExpression(),
-                  t.identifier('moduleId')
-                ),
-                t.identifier('moduleId')
-              )
-            ),
-            ...bindings
-          ])
-        ),
-
-        ...methods
-      ],
-      [t.tSExpressionWithTypeArguments(t.identifier(implementsClassName))]
-    )
-  );
-};
-
-const ADDRESS_ACCESSOR_FN = t.classProperty(
-  t.identifier(ADDRESS_GETTER_FN_NAME),
-  arrowFunctionExpression(
-    [],
-    t.blockStatement([
-      t.ifStatement(
-        t.unaryExpression(
-          '!',
-          t.memberExpression(t.thisExpression(), CLASS_VARS._moduleAddress)
-        ),
-        t.blockStatement([
-          t.variableDeclaration(
-            'const',
-            [
-              t.variableDeclarator(
-                t.identifier('address'),
-                t.awaitExpression(
+              ),
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  t.memberExpression(
+                    t.thisExpression(),
+                    CLASS_VARS.accountClient
+                  ),
                   t.callExpression(
                     t.memberExpression(
-                      t.memberExpression(
-                        t.thisExpression(),
-                        CLASS_VARS.accountQueryClient
-                      ),
-                      t.identifier('getModuleAddress')
+                      t.identifier(ABSTRACT_ACCOUNT_CLIENT),
+                      t.identifier('fromQueryClient')
                     ),
                     [
                       t.memberExpression(
                         t.thisExpression(),
-                        t.identifier('moduleId')
-                      )
+                        CLASS_VARS.accountQueryClient
+                      ),
+                      t.identifier('abstractClient')
                     ]
                   )
                 )
-              )
-            ]
-          ),
-          t.ifStatement(
-            t.binaryExpression(
-              '===',
-              t.identifier('address'),
-              t.nullLiteral()
-            ),
-            t.blockStatement([
-              t.throwStatement(
-                t.newExpression(
-                  t.identifier('Error'),
-                  [t.templateLiteral(
-                    [
-                      t.templateElement({ raw: 'Module ', cooked: 'Module ' }, false),
-                      t.templateElement({ raw: ' not installed', cooked: ' not installed' }, true)
-                    ],
-                    [t.memberExpression(t.thisExpression(), t.identifier('moduleId'))]
-                  )]
-                )
-              )
+              ),
+              ...bindings
             ])
           ),
-          t.expressionStatement(
-            t.assignmentExpression(
-              '=',
-              t.memberExpression(t.thisExpression(), CLASS_VARS._moduleAddress),
-              t.identifier('address')
+
+          ...methods
+        ],
+        [t.tSExpressionWithTypeArguments(t.identifier(implementsClassName))],
+        extendsClassName ? t.identifier(extendsClassName) : null
+      )
+    );
+  };
+
+  /*
+    deposit = async (params: CamelCasedProperties<Extract<ExecuteMsg, {
+      deposit: unknown;
+    }>["deposit"]>, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
+      return this._execute(AutocompounderExecuteMsgBuilder.deposit(params), fee, memo, _funds);
+    };
+   */
+  const createAppExecMethod = (
+    context: RenderContext,
+    moduleName: string,
+    schema: any
+  ) => {
+    const underscoreName = Object.keys(schema.properties)[0];
+    const methodName = camel(underscoreName);
+
+    const execParams = Object.keys(
+      schema.properties[underscoreName]?.properties ?? {}
+    );
+
+    // the actual type of the ref
+    const methodParam = t.identifier('params');
+    methodParam.typeAnnotation = createExtractTypeAnnotation(
+      underscoreName,
+      moduleName
+    );
+
+    const methodParameters = extractCamelcasedMethodParams(context, 'ExecuteMsg', schema, underscoreName);
+
+    return t.classProperty(
+      t.identifier(methodName),
+      arrowFunctionExpression(
+        methodParameters
+          ? [...methodParameters, ...CONSTANT_EXEC_PARAMS]
+          : CONSTANT_EXEC_PARAMS,
+        t.blockStatement([
+          t.returnStatement(
+            t.callExpression(
+              t.memberExpression(t.thisExpression(), t.identifier('_execute')),
+              [
+                t.callExpression(
+                  t.memberExpression(
+                    t.identifier(`${moduleName}ExecuteMsgBuilder`),
+                    t.identifier(methodName)
+                  ),
+                  methodParameters
+                ),
+                ...OPTIONAL_FIXED_EXECUTE_PARAMS
+              ]
             )
           )
-        ])
-      ),
-      t.returnStatement(
-        // The address must be available because we just retrieved it
-        t.memberExpression(t.thisExpression(), t.identifier('_moduleAddress!'))
+        ]),
+        promiseTypeAnnotation('ExecuteResult'),
+        true
       )
-    ]),
-    promiseTypeAnnotation('string'),
-    true
-  )
-);
+    );
+  };
 
+  const createStaticExecMethodMsgBuilder = (
+    context: RenderContext,
+    jsonschema: any,
+    msgTitle: string
+  ) => {
+    const underscoreName = Object.keys(jsonschema.properties)[0];
+    const methodName = camel(underscoreName);
+    const param = createTypedObjectParams(
+      context,
+      jsonschema.properties[underscoreName]
+    );
+    const args = getWasmMethodArgs(
+      context,
+      jsonschema.properties[underscoreName]
+    );
 
-const connectSigningClientMethod = (mutClientName: string) => {
-  return t.classProperty(
-    t.identifier('connectSigningClient'),
-    arrowFunctionExpression(
-      [
-        identifier(
-          'signingClient',
-          t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier('SigningCosmWasmClient'))
-          )
-        ),
-        identifier('address', t.tsTypeAnnotation(t.tsStringKeyword()))
-      ],
-      t.blockStatement([
-        t.returnStatement(
-          t.newExpression(t.identifier(mutClientName), [
+    const msgAction = t.identifier(underscoreName);
+
+    // what the underscore named property in the message is assigned to
+    let msgActionValue: t.Expression
+    if (param?.type === 'Identifier') {
+      msgActionValue = t.identifier(param.name);
+    } else {
+      msgActionValue = t.tsAsExpression(t.objectExpression(args), t.tsTypeReference(t.identifier('const')));
+    }
+
+    if (param) {
+      param.typeAnnotation = createExtractTypeAnnotation(underscoreName, msgTitle);
+    }
+
+    return t.classProperty(
+      t.identifier(methodName),
+      arrowFunctionExpression(
+        // params
+        param
+          ? [
+            // props
+            param
+          ]
+          : [],
+        // body
+        t.blockStatement([
+          t.returnStatement(
             t.objectExpression([
               t.objectProperty(
-                t.identifier('accountId'),
-                t.memberExpression(
-                  t.memberExpression(
-                    t.thisExpression(),
-                    CLASS_VARS.accountQueryClient
-                  ),
-                  t.identifier('accountId')
-                )
-              ),
-              t.objectProperty(
-                t.identifier('managerAddress'),
-                t.memberExpression(
-                  t.memberExpression(
-                    t.thisExpression(),
-                    CLASS_VARS.accountQueryClient
-                  ),
-                  t.identifier('managerAddress')
-                )
-              ),
-              t.objectProperty(
-                t.identifier('proxyAddress'),
-                t.memberExpression(
-                  t.memberExpression(
-                    t.thisExpression(),
-                    CLASS_VARS.accountQueryClient
-                  ),
-                  t.identifier('proxyAddress')
-                )
-              ),
-              t.objectProperty(
-                t.identifier('moduleId'),
-                t.memberExpression(t.thisExpression(), t.identifier('moduleId'))
-              ),
-              t.objectProperty(
-                t.identifier('abstractClient'),
-                t.callExpression(
-                  t.memberExpression(
-                    t.memberExpression(
-                      t.memberExpression(
-                        t.thisExpression(),
-                        CLASS_VARS.accountQueryClient
-                      ),
-                      t.identifier('abstract')
-                    ),
-                    t.identifier('connectSigningClient')
-                  ),
-                  [t.identifier('signingClient'), t.identifier('address')]
-                )
+                msgAction,
+                msgActionValue
               )
             ])
-          ])
-        )
-      ]),
-      t.tsTypeAnnotation(t.tsTypeReference(t.identifier(mutClientName)))
-    )
-  );
-};
-
-/*
-  public pendingClaims = async (
-    params: ExtractCamelizedParams<AutocompounderQueryMsg, 'pending_claims'>
-  ): Promise<Uint128> => {
-    return this._query(AutocompounderQueryMsgBuilder.pendingClaims(params))
-  }
- */
-const createAppQueryMethod = (
-  context: RenderContext,
-  moduleName: string,
-  schema: any
-) => {
-  const underscoreName = Object.keys(schema.properties)[0];
-  const methodName = camel(underscoreName);
-  const responseType = getResponseType(context, underscoreName);
-
-  const queryParams = Object.keys(
-    schema.properties[underscoreName]?.properties ?? {}
-  );
-
-  // the actual type of the ref
-  const methodParam = t.identifier('params');
-  methodParam.typeAnnotation = createExtractTypeAnnotation(
-    underscoreName,
-    moduleName
-  );
-
-  const parameters = extractCamelcasedMethodParams(
-    'QueryMsg',
-    schema,
-    underscoreName
-  );
-
-  return t.classProperty(
-    t.identifier(methodName),
-    arrowFunctionExpression(
-      parameters,
-      t.blockStatement([
-        t.returnStatement(
-          t.callExpression(
-            t.memberExpression(t.thisExpression(), t.identifier('_query')),
-            [
-              t.callExpression(
-                t.memberExpression(
-                  t.identifier(`${moduleName}QueryMsgBuilder`),
-                  t.identifier(methodName)
-                ),
-                parameters
-              )
-            ]
           )
-        )
-      ]),
-      promiseTypeAnnotation(responseType),
+        ]),
+        // return type
+        t.tsTypeAnnotation(t.tsTypeReference(t.identifier(msgTitle))),
+        false
+      ),
+      null,
+      null,
+      false,
+      // static
       true
-    )
-  );
-};
-
-export const createAppExecuteClass = (
-  context: RenderContext,
-  uncheckedModuleName: string,
-  className: string,
-  implementsClassName: string,
-  extendsClassName: string,
-  execMsg: ExecuteMsg
-): ExportNamedDeclaration => {
-  const moduleName = pascal(uncheckedModuleName);
-
-  context.addUtils([
-    ABSTRACT_ACCOUNT_CLIENT,
-    'StdFee',
-    'Coin',
-    ABSTRACT_CLIENT,
-    ABSTRACT_ACCOUNT_ID
-  ]);
-
-  const propertyNames = getMessageProperties(execMsg)
-    .map((method) => Object.keys(method.properties)?.[0])
-    .filter(Boolean);
-
-  const bindings = propertyNames.map(camel).map(bindMethod);
-
-  const methods = getMessageProperties(execMsg).map((schema) => {
-    return createAppExecMethod(context, moduleName, schema);
-  });
-
-  methods.push(EXECUTE_APP_FN);
-
-  return t.exportNamedDeclaration(
-    classDeclaration(
-      className,
-      [
-        // client
-        classProperty(
-          'accountClient',
-          t.tsTypeAnnotation(
-            t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_CLIENT))
-          )
-        ),
-
-        // constructor
-        t.classMethod(
-          'constructor',
-          t.identifier('constructor'),
-          // TODO: typing
-          [
-            autoTypedObjectPattern([
-              shorthandProperty(
-                'abstractClient',
-                t.tsTypeAnnotation(
-                  t.tsTypeReference(t.identifier(ABSTRACT_CLIENT))
-                )
-              ),
-              shorthandProperty(
-                'accountId',
-                t.tsTypeAnnotation(
-                  t.tsTypeReference(t.identifier(ABSTRACT_ACCOUNT_ID))
-                )
-              ),
-              shorthandProperty(
-                'managerAddress',
-                t.tsTypeAnnotation(t.tsStringKeyword())
-              ),
-              shorthandProperty(
-                'proxyAddress',
-                t.tsTypeAnnotation(t.tsStringKeyword())
-              ),
-              shorthandProperty(
-                'moduleId',
-                t.tsTypeAnnotation(t.tsStringKeyword())
-              )
-            ])
-          ],
-          t.blockStatement([
-            t.expressionStatement(
-              // TODO!
-              t.callExpression(t.super(), [
-                t.objectExpression([
-                  t.objectProperty(
-                    identifier('abstractQueryClient', undefined),
-                    t.identifier('abstractClient'),
-                    false,
-                    true
-                  ),
-                  shorthandProperty('accountId'),
-                  shorthandProperty('managerAddress'),
-                  shorthandProperty('proxyAddress'),
-                  shorthandProperty('moduleId')
-                ])
-              ])
-            ),
-            t.expressionStatement(
-              t.assignmentExpression(
-                '=',
-                t.memberExpression(
-                  t.thisExpression(),
-                  CLASS_VARS.accountClient
-                ),
-                t.callExpression(
-                  t.memberExpression(
-                    t.identifier(ABSTRACT_ACCOUNT_CLIENT),
-                    t.identifier('fromQueryClient')
-                  ),
-                  [
-                    t.memberExpression(
-                      t.thisExpression(),
-                      CLASS_VARS.accountQueryClient
-                    ),
-                    t.identifier('abstractClient')
-                  ]
-                )
-              )
-            ),
-            ...bindings
-          ])
-        ),
-
-        ...methods
-      ],
-      [t.tSExpressionWithTypeArguments(t.identifier(implementsClassName))],
-      extendsClassName ? t.identifier(extendsClassName) : null
-    )
-  );
-};
-
-/*
-  deposit = async (params: CamelCasedProperties<Extract<ExecuteMsg, {
-    deposit: unknown;
-  }>["deposit"]>, fee?: number | StdFee | "auto", memo?: string, _funds?: Coin[]): Promise<ExecuteResult> => {
-    return this._execute(AutocompounderExecuteMsgBuilder.deposit(params), fee, memo, _funds);
+    );
   };
- */
-const createAppExecMethod = (
-  context: RenderContext,
-  moduleName: string,
-  schema: any
-) => {
-  const underscoreName = Object.keys(schema.properties)[0];
-  const methodName = camel(underscoreName);
-
-  const execParams = Object.keys(
-    schema.properties[underscoreName]?.properties ?? {}
-  );
-
-  // the actual type of the ref
-  const methodParam = t.identifier('params');
-  methodParam.typeAnnotation = createExtractTypeAnnotation(
-    underscoreName,
-    moduleName
-  );
-
-  const methodParameters = extractCamelcasedMethodParams(
-    'ExecuteMsg',
-    schema,
-    underscoreName
-  );
-
-  return t.classProperty(
-    t.identifier(methodName),
-    arrowFunctionExpression(
-      methodParameters
-        ? [...methodParameters, ...CONSTANT_EXEC_PARAMS]
-        : CONSTANT_EXEC_PARAMS,
-      t.blockStatement([
-        t.returnStatement(
-          t.callExpression(
-            t.memberExpression(t.thisExpression(), t.identifier('_execute')),
-            [
-              t.callExpression(
-                t.memberExpression(
-                  t.identifier(`${moduleName}ExecuteMsgBuilder`),
-                  t.identifier(methodName)
-                ),
-                methodParameters
-              ),
-              ...OPTIONAL_FIXED_EXECUTE_PARAMS
-            ]
-          )
-        )
-      ]),
-      promiseTypeAnnotation('ExecuteResult'),
-      true
-    )
-  );
-};
-
-const createStaticExecMethodMsgBuilder = (
-  context: RenderContext,
-  jsonschema: any,
-  msgTitle: string
-) => {
-  const underscoreName = Object.keys(jsonschema.properties)[0];
-  const methodName = camel(underscoreName);
-  const obj = createTypedObjectParams(
-    context,
-    jsonschema.properties[underscoreName]
-  );
-  const args = getWasmMethodArgs(
-    context,
-    jsonschema.properties[underscoreName]
-  );
-
-  if (obj)
-    obj.typeAnnotation = createExtractTypeAnnotation(underscoreName, msgTitle);
-
-  return t.classProperty(
-    t.identifier(methodName),
-    arrowFunctionExpression(
-      // params
-      obj
-        ? [
-            // props
-            obj
-          ]
-        : [],
-      // body
-      t.blockStatement([
-        t.returnStatement(
-          t.objectExpression([
-            t.objectProperty(
-              t.identifier(underscoreName),
-              t.tsAsExpression(
-                t.objectExpression(args),
-                t.tsTypeReference(t.identifier('const'))
-              )
-            )
-          ])
-        )
-      ]),
-      // return type
-      t.tsTypeAnnotation(t.tsTypeReference(t.identifier(msgTitle))),
-      false
-    ),
-    null,
-    null,
-    false,
-    // static
-    true
-  );
-};

--- a/packages/wasm-ast-types/src/abstract-app/query-options-factory.spec.ts
+++ b/packages/wasm-ast-types/src/abstract-app/query-options-factory.spec.ts
@@ -2,6 +2,7 @@ import { expectCode, makeContext } from '../../test-utils';
 import { query as etfQuery } from '../../../../__fixtures__/abstract/apps/etf.json';
 import { query as subscriptionQuery } from '../../../../__fixtures__/abstract/apps/subscription.json';
 import { query as autocompounderQuery } from '../../../../__fixtures__/abstract/apps/autocompounder.json';
+import { query as ibcmailClientQuery } from '../../../../__fixtures__/abstract/apps/ibcmail/client.json';
 import { createQueryOptionsFactory } from './query-options-factory';
 import query_msg from '../../../../__fixtures__/basic/query_msg.json';
 
@@ -29,6 +30,18 @@ it('autocompounderQueryMsg', () => {
       ctx,
       'Autocompounder',
       autocompounderQuery,
+      'contract'
+    )
+  );
+});
+
+it('ibcmailClientQueryMsg', () => {
+  const ctx = makeContext(ibcmailClientQuery);
+  expectCode(
+    createQueryOptionsFactory(
+      ctx,
+      'IbcMailClient',
+      ibcmailClientQuery,
       'contract'
     )
   );

--- a/packages/wasm-ast-types/src/client/client.ts
+++ b/packages/wasm-ast-types/src/client/client.ts
@@ -188,6 +188,7 @@ export const getWasmMethodArgs = (
     // tuple struct or otherwise, use the name of the reference
     if (!keys.length && obj?.oneOf) {
       // TODO????? ADAIR
+      console.warn("We are unsure how to handle this scenario in getWasmMethodArgs", obj.oneOf)
     }
   }
 
@@ -234,10 +235,10 @@ export const createWasmExecMethod = (
     arrowFunctionExpression(
       param
         ? [
-            // props
-            param,
-            ...CONSTANT_EXEC_PARAMS
-          ]
+          // props
+          param,
+          ...CONSTANT_EXEC_PARAMS
+        ]
         : CONSTANT_EXEC_PARAMS,
       t.blockStatement([
         t.returnStatement(

--- a/packages/wasm-ast-types/src/client/client.ts
+++ b/packages/wasm-ast-types/src/client/client.ts
@@ -188,7 +188,6 @@ export const getWasmMethodArgs = (
     // tuple struct or otherwise, use the name of the reference
     if (!keys.length && obj?.oneOf) {
       // TODO????? ADAIR
-      console.warn("We are unsure how to handle this scenario in getWasmMethodArgs", obj.oneOf)
     }
   }
 

--- a/packages/wasm-ast-types/src/react-query/react-query.ts
+++ b/packages/wasm-ast-types/src/react-query/react-query.ts
@@ -248,36 +248,36 @@ const ENABLED_QUERY_OPTION = t.objectProperty(
 function buildQueryOptions(options: ReactQueryOptions) {
   return options.optionalClient
     ? t.objectExpression([
-        t.spreadElement(t.identifier('options')),
-        t.objectProperty(
-          t.identifier('enabled'),
-          t.logicalExpression(
-            '&&',
-            t.unaryExpression(
-              '!',
-              t.unaryExpression('!', t.identifier('client'))
-            ),
-            t.conditionalExpression(
-              // explicitly check for undefined
-              t.binaryExpression(
-                '!=',
-                t.optionalMemberExpression(
-                  t.identifier('options'),
-                  t.identifier('enabled'),
-                  false,
-                  true
-                ),
-                t.identifier('undefined')
-              ),
-              t.memberExpression(
+      t.spreadElement(t.identifier('options')),
+      t.objectProperty(
+        t.identifier('enabled'),
+        t.logicalExpression(
+          '&&',
+          t.unaryExpression(
+            '!',
+            t.unaryExpression('!', t.identifier('client'))
+          ),
+          t.conditionalExpression(
+            // explicitly check for undefined
+            t.binaryExpression(
+              '!=',
+              t.optionalMemberExpression(
                 t.identifier('options'),
-                t.identifier('enabled')
+                t.identifier('enabled'),
+                false,
+                true
               ),
-              t.booleanLiteral(true)
-            )
+              t.identifier('undefined')
+            ),
+            t.memberExpression(
+              t.identifier('options'),
+              t.identifier('enabled')
+            ),
+            t.booleanLiteral(true)
           )
         )
-      ])
+      )
+    ])
     : t.identifier('options');
 }
 
@@ -1035,7 +1035,7 @@ const generateUseQueryQueryKey = ({
 
   const contractAddressExpression = t.optionalMemberExpression(
     t.identifier('client'),
-    t.identifier(isAbstractApp ? 'moduleId' : 'contractAddress'),
+    t.identifier(isAbstractApp ? '_moduleAddress' : 'contractAddress'),
     false,
     optionalClient
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9187,7 +9187,7 @@ walker@^1.0.8:
     makeerror "1.0.12"
 
 "wasm-ast-types@file:packages/wasm-ast-types":
-  version "0.26.2"
+  version "0.26.3"
   dependencies:
     "@babel/runtime" "^7.18.9"
     "@babel/types" "7.18.10"


### PR DESCRIPTION
Title. Tuple variants were not being generated properly for Abstract Apps.

Here's a test diff:
<img width="1356" alt="CleanShot 2024-05-20 at 19 32 05@2x" src="https://github.com/AbstractSDK/ts-codegen/assets/32375605/de8299d5-3dfb-42e0-b166-621e51ac4afe">

Secondly, we ensure that query keys are by module address, not module id. 